### PR TITLE
chore: drop support for nodejs 8.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: node:10
+  image: node:12
 
 lint_task:
   install_script: npm install
@@ -8,9 +8,9 @@ lint_task:
 test_task:
   container:
     matrix:
-      image: node:11
+      image: node:13
+      image: node:12
       image: node:10
-      image: node:8
   install_script: npm install
   test_script: npm test
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "src/.gcloudignore"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "scripts": {
     "test": "c8 mocha build/test --require source-map-support/register --timeout 60000",


### PR DESCRIPTION
BREAKING CHANGE: This drops support for node.js 8.x and below. 